### PR TITLE
Issue 20: Add -c / --config flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ $ npm install
 |------------------------------------------------------|---------------------------------------------------|
 | -v, --version                                        | displays app name and version                     |
 | -h, --help                                           | show help                                         |
-| -s, --stylesheet <'URL to a CSS stylesheet'>         | CSS stylesheet to be used in generated HTNL files |
+| -s, --stylesheet <'URL to a CSS stylesheet'>         | CSS stylesheet to be used in generated HTML files |
 | -l, --lang <'language'>                              | language to be used in generated HTML files       |
+| -c, --config <'.toml config file'>                   | path to .toml config file                         |
 
 ### Usage
 #### Check Version of the app

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,2 @@
+lang = "fr-CA"
+stylesheet = "https://cdn.jsdelivr.net/npm/water.css@2/out/water.css"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@ltd/j-toml": "^1.38.0",
         "ts-node": "^10.9.1",
         "yargs": "^17.7.2"
       },
@@ -49,6 +50,11 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@ltd/j-toml": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@ltd/j-toml/-/j-toml-1.38.0.tgz",
+      "integrity": "sha512-lYtBcmvHustHQtg4X7TXUu1Xa/tbLC3p2wLvgQI+fWVySguVZJF60Snxijw5EiohumxZbR10kWYFFebh1zotiw=="
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
@@ -373,6 +379,11 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "@ltd/j-toml": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@ltd/j-toml/-/j-toml-1.38.0.tgz",
+      "integrity": "sha512-lYtBcmvHustHQtg4X7TXUu1Xa/tbLC3p2wLvgQI+fWVySguVZJF60Snxijw5EiohumxZbR10kWYFFebh1zotiw=="
     },
     "@tsconfig/node10": {
       "version": "1.0.9",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/avelynhc/til_tracker#readme",
   "dependencies": {
+    "@ltd/j-toml": "^1.38.0",
     "ts-node": "^10.9.1",
     "yargs": "^17.7.2"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ const argv = yargs
     })
     .option('c', {
         alias: 'config',
-        describe: 'Path to TOML config file',
+        describe: 'Path to .toml config file',
         default: '',
         type: 'string',
         demandOption: false,
@@ -56,12 +56,8 @@ if (argv.config !== '') {
             process.exit(-1);
         }
         const configOptions = TOML.parse(fs.readFileSync(configPath));
-        configOptions.lang ?
-            selectedLang = configOptions.lang :
-            selectedLang = 'en-CA';
-        configOptions.stylesheet ?
-            cssLink = configOptions.stylesheet :
-            cssLink = '';
+        selectedLang = configOptions.lang || 'en-CA';
+        cssLink = configOptions.stylesheet || '';
     } catch (err: any) {
         console.error(err.message);
         process.exit(-1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,13 @@ const argv = yargs
         type: 'string',
         demandOption: false,
     })
+    .option('c', {
+        alias: 'config',
+        describe: 'Path to TOML config file',
+        default: '',
+        type: 'string',
+        demandOption: false,
+    })
     .alias('h', 'help')
     .alias('v', 'version')
     .version(parsedInfo.name + ' ' + parsedInfo.version)


### PR DESCRIPTION
Addresses #20.

- The `-c` / `--config` flag accepts a filepath to a .toml file.
- If the file is missing, is not a .toml file, or otherwise cannot be parsed, the program will show an appropriate error message and exit with a code of -1.
- Options not specified in the config file will assume default values. 
- Options in the config file take priority over options on the command line.