### PR TITLE
use showdown library to convert md to html instead of using regex

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -13,8 +13,10 @@
     <div>
         <h1>Welcome to til-tracker website!</h1>
         <ul>
-            <li><a href="sample.html">Fist sample html file</a></li>
-            <li><a href="sample2.html">Second sample html file</a></li>
+            <li><a href="../til/test.html">Fist sample html file</a></li>
+            <li><a href="../til/test1.html">Second sample html file</a></li>
+            <li><a href="../til/test2.html">Third sample html file</a></li>
+            <li><a href="../til/test3.html">Fourth sample html file</a></li>
         </ul>
     </div>
 </body>

--- a/examples/test.md
+++ b/examples/test.md
@@ -17,3 +17,13 @@ Should be a paragraph 1
 Should be a paragraph 2
 
 Should be a paragraph 3
+
+---
+
+> this is a block quote
+
+```typescript
+for(let i:number=0; i<cups.length; i++) {
+    console.log(cups[i]);
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@ltd/j-toml": "^1.38.0",
+        "showdown": "^2.1.0",
         "ts-node": "^10.9.1",
         "yargs": "^17.7.2"
       },
@@ -156,6 +157,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -209,6 +218,21 @@
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/showdown": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
+      "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
+      "dependencies": {
+        "commander": "^9.0.0"
+      },
+      "bin": {
+        "showdown": "bin/showdown.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://www.paypal.me/tiviesantos"
       }
     },
     "node_modules/string-width": {
@@ -461,6 +485,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="
+    },
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -500,6 +529,14 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
+    },
+    "showdown": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
+      "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
+      "requires": {
+        "commander": "^9.0.0"
+      }
     },
     "string-width": {
       "version": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "homepage": "https://github.com/avelynhc/til_tracker#readme",
   "dependencies": {
     "@ltd/j-toml": "^1.38.0",
+    "showdown": "^2.1.0",
     "ts-node": "^10.9.1",
     "yargs": "^17.7.2"
   },

--- a/src/helper/fileHandler.ts
+++ b/src/helper/fileHandler.ts
@@ -3,6 +3,9 @@ import * as readFilePath from 'path';
 import { htmlConversion } from './htmlConversion';
 import { errorHandling } from '../fileParser';
 import { isMarkdownFile, isTextFile } from "./check";
+
+const showdown = require('showdown');
+const converter = new showdown.Converter()
 let body: string = '';
 
 export function fileHandler(inputPath: string, cssLink: string, selectedLang: string, outputFolder: string) {
@@ -16,7 +19,7 @@ export function fileHandler(inputPath: string, cssLink: string, selectedLang: st
         if (isTextFile(inputPath)) {
             body = parseTextFileContent(data);
         } else if (isMarkdownFile(inputPath)) {
-            body = parseMarkdownFileContent(data);
+            body = converter.makeHtml(data);
         } else {
             // Reaching this branch is only possible when user provides a file (not folder) as commandline argument.
             // The dirHandler function automatically filters out unsupported files.
@@ -37,30 +40,4 @@ function parseTextFileContent(content: string): string {
         .map((para: string) =>
             `<p>${para.replace(/\r?\n/, ' ')}</p>`)
         .join('\n');
-}
-
-// Parses the content of a markdown file
-function parseMarkdownFileContent(content: string): string {
-    return content
-        .replace(/(\r?\n){1}/, ' ') // Aggregate text at gaps of single newlines
-        .split(/\r?\n/)
-        .filter(line => line?.length > 0) // Remove empty lines
-        .map((line: string) => {
-            return formatHtmlForMarkdownLine(line)
-        })
-        .join('\n'); // Join all the generated tags
-}
-
-function formatHtmlForMarkdownLine(line: string) {
-    return line
-        .replace(/^#\s(.+)$/gm, '<h1>$1</h1>') // heading 1
-        .replace(/^##\s(.+)$/gm, '<h2>$1</h2>') // heading 2
-        .replace(/^###\s(.+)$/gm, '<h3>$1</h3>') // heading 3
-        .replace(/^####\s(.+)$/gm, '<h4>$1</h4>') // heading 4
-        .replace(/^#####\s(.+)$/gm, '<h5>$1</h5>') // heading 5
-        .replace(/^######\s(.+)$/gm, '<h6>$1</h6>') // heading 6
-        .replace(/^(?!<h[1-6]>|<ul>|<ol>|<li>|<a>).+$/gm, '<p>$&</p>') // paragraph
-        .replace(/\[(.+?)\]\((.+?)\)/g, '<a href=$2>$1</a>') //  link
-        .replace(/\*\*(.*?)\*\*/g, '<b>$1</b>') // bold
-        .replace(/\*(.*?)\*/g, '<i>$1</i>') // italic
 }


### PR DESCRIPTION
fixes #23    

- used [showdown library](https://www.npmjs.com/package/showdown) for `.md` to `.html` file conversion instead of regex
- changed index.html
- edited `.md` file for testing